### PR TITLE
feat: add possibility for customizing parser and encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,15 @@
       "name": "exdenv",
       "version": "1.0.2",
       "license": "MIT",
-      "dependencies": {
-        "dotenv": "^16.3.1"
-      },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.1.0",
         "@rollup/plugin-terser": "^0.4.3",
+        "@rollup/plugin-typescript": "^11.1.2",
         "@types/node": "^20.4.4",
         "@types/tap": "^15.0.8",
         "commitizen": "^4.3.0",
         "cz-conventional-changelog": "^3.3.0",
+        "dotenv": "^16.3.1",
         "prettier": "^3.0.0",
         "rimraf": "^5.0.1",
         "rollup": "^3.26.3",
@@ -854,6 +853,32 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-typescript": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.2.tgz",
+      "integrity": "sha512-0ghSOCMcA7fl1JM+0gYRf+Q/HWyg+zg7/gDSc+fRLmlJWcW5K1I+CLRzaRhXf4Y3DRyPnnDo4M2ktw+a6JcDEg==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^2.14.0||^3.0.0",
+        "tslib": "*",
+        "typescript": ">=3.7.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        },
+        "tslib": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
@@ -1680,6 +1705,7 @@
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
       "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -6302,7 +6328,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
-      "optional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7293,6 +7318,16 @@
         "terser": "^5.17.4"
       }
     },
+    "@rollup/plugin-typescript": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-typescript/-/plugin-typescript-11.1.2.tgz",
+      "integrity": "sha512-0ghSOCMcA7fl1JM+0gYRf+Q/HWyg+zg7/gDSc+fRLmlJWcW5K1I+CLRzaRhXf4Y3DRyPnnDo4M2ktw+a6JcDEg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^5.0.1",
+        "resolve": "^1.22.1"
+      }
+    },
     "@rollup/pluginutils": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.2.tgz",
@@ -7876,7 +7911,8 @@
     "dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
+      "dev": true
     },
     "doubter": {
       "version": "2.1.0",
@@ -11104,8 +11140,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "unicode-length": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "./package.json": "./package.json"
   },
   "scripts": {
-    "build": "npm run clean && tsc && rollup -c",
+    "build": "npm run clean && rollup -c",
     "test": "tap",
     "clean": "rimraf ./lib",
     "prune": "npm run clean && rimraf ./node_modules"
@@ -46,17 +46,16 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.1.0",
     "@rollup/plugin-terser": "^0.4.3",
+    "@rollup/plugin-typescript": "^11.1.2",
     "@types/node": "^20.4.4",
     "@types/tap": "^15.0.8",
     "commitizen": "^4.3.0",
     "cz-conventional-changelog": "^3.3.0",
+    "dotenv": "^16.3.1",
     "prettier": "^3.0.0",
     "rimraf": "^5.0.1",
     "rollup": "^3.26.3",
     "tap": "^16.3.7"
-  },
-  "dependencies": {
-    "dotenv": "^16.3.1"
   },
   "peerDependencies": {
     "doubter": "^2.1.0"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,13 @@
+const typescript = require('@rollup/plugin-typescript');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const terser = require('@rollup/plugin-terser');
 
 module.exports = {
-  input: './lib/index.js',
+  input: './src/main/index.ts',
   external: 'dotenv',
   output: {
     file: './lib/index.js',
     format: 'cjs',
   },
-  plugins: [nodeResolve(), terser()],
+  plugins: [typescript(), nodeResolve(), terser()],
 };


### PR DESCRIPTION
Implemented:

1. param for setting encoding for loading .env files
2. param for custom parse function .env files

Also implemented:

1. Simplified the building process, now the only rollup's used for building and transpiling
2. dotenv library was replaced to devDependecnies

Closes #12 